### PR TITLE
URL changed in wheels

### DIFF
--- a/.github/workflows/wheels_linux.yml
+++ b/.github/workflows/wheels_linux.yml
@@ -6,12 +6,6 @@ on:
     branches: [ master ]
       
 jobs:
-  vm:
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          echo "Do nothing here"
-        name: Dummy job
   container:
     runs-on: ubuntu-latest
     container: quay.io/pypa/manylinux2010_x86_64

--- a/.github/workflows/wheels_linux.yml
+++ b/.github/workflows/wheels_linux.yml
@@ -24,7 +24,7 @@ jobs:
           /opt/python/cp38-cp38/bin/python -m pip install cmake 
           ln -s /opt/python/cp38-cp38/bin/cmake /usr/local/bin/cmake
           cd ~ && tree
-          git clone https://github.com/dilawar/Smoldyn -b master --depth 10
+          git clone https://github.com/ssandrews/Smoldyn -b master --depth 10
           cd Smoldyn/scripts && PYPI_PASSWORD=$SMOLDYN_PYPI_TOKEN ./build_wheels_linux.sh 
         name: Building wheel in ManuLinux container
 

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -2148,7 +2148,7 @@ HAVE_DOT               = YES
 # Minimum value: 0, maximum value: 32, default value: 0.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_NUM_THREADS        = 3
+DOT_NUM_THREADS        = 2
 
 # When you want a differently looking font in the dot files that doxygen
 # generates you can specify the font name using DOT_FONTNAME. You need to make
@@ -2255,7 +2255,7 @@ INCLUDED_BY_GRAPH      = YES
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-CALL_GRAPH             = YES
+CALL_GRAPH             = NO
 
 # If the CALLER_GRAPH tag is set to YES then doxygen will generate a caller
 # dependency graph for every global function or class method.
@@ -2267,7 +2267,7 @@ CALL_GRAPH             = YES
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-CALLER_GRAPH           = YES
+CALLER_GRAPH           = NO
 
 # If the GRAPHICAL_HIERARCHY tag is set to YES then doxygen will graphical
 # hierarchy of all classes instead of a textual one.


### PR DESCRIPTION
After the successful merge of #37, there is no need to build wheels from my fork. This repo contains all required environment variables and scripts. 

Changed the URL to the official repo. Also fixes to readthedocs build.