### PR TITLE
Fixes in version string

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 
 # CI/CD can also set this variable. If not, use the default one.
 if(NOT SMOLDYN_VERSION)
-    string(TIMESTAMP STAMP "%Y%d%m")
+    string(TIMESTAMP STAMP "%Y%m%d")
     set(SMOLDYN_VERSION "2.63.dev${STAMP}")
 endif()
 message(STATUS "Smoldyn version set to: '${SMOLDYN_VERSION}'")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 # CI/CD can also set this variable. If not, use the default one.
 if(NOT SMOLDYN_VERSION)
     string(TIMESTAMP STAMP "%Y%m%d")
-    set(SMOLDYN_VERSION "2.63.dev${STAMP}")
+    set(SMOLDYN_VERSION "2.63a1.dev${STAMP}")
 endif()
 message(STATUS "Smoldyn version set to: '${SMOLDYN_VERSION}'")
 

--- a/scripts/build_wheels_linux.sh
+++ b/scripts/build_wheels_linux.sh
@@ -9,8 +9,6 @@ WHEELHOUSE=${1-$HOME/wheelhouse}
 echo "Path to store wheels : $WHEELHOUSE"
 rm -rf $WHEELHOUSE && mkdir -p $WHEELHOUSE
 
-SMOLDYN_VERSION=$(bash ${SCRIPT_DIR}/get_version.sh)
-
 PYDIR37=/opt/python/cp37-cp37m/
 PYDIR38=/opt/python/cp38-cp38/
 PYDIR39=/opt/python/cp39-cp39/
@@ -33,8 +31,7 @@ for PYDIR in $PYDIR39 $PYDIR38 $PYDIR37; do
             -DCMAKE_INSTALL_PREFIX=/usr \
 	        -DPython3_EXECUTABLE=$PYTHON \
 	        -DPython3_INCLUDE_DIR=$PYINDIR \
-	        -DPython3_LIBRARY=$PYLIB \
-            -DSMOLDYN_VERSION=${SMOLDYN_VERSION}
+	        -DPython3_LIBRARY=$PYLIB 
         make -j`nproc` 
         make wheel 
         export PYTHONPATH=$(pwd)/py

--- a/scripts/build_wheels_osx.sh
+++ b/scripts/build_wheels_osx.sh
@@ -11,8 +11,6 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export PATH=/usr/local/bin:$PATH
 
-SMOLDYN_VERSION=$(bash $SCRIPT_DIR/get_version.sh)
-
 WHEELHOUSE=$HOME/wheelhouse
 rm -rf $WHEELHOUSE && mkdir -p $WHEELHOUSE
 
@@ -41,7 +39,6 @@ PLATFORM=$($PYTHON -c "import distutils.util; print(distutils.util.get_platform(
     cmake ../.. \
         -DOPTION_PYTHON=ON \
         -DOPTION_EXAMPLES=ON \
-        -DSMOLDYN_VERSION:STRING=${SMOLDYN_VERSION} \
         -DPython3_EXECUTABLE=$PYTHON
     make -j4 
     make wheel

--- a/scripts/build_wheels_osx.sh
+++ b/scripts/build_wheels_osx.sh
@@ -29,6 +29,7 @@ $PYTHON -m pip install numpy --upgrade
 $PYTHON -m pip install delocate --upgrade
 $PYTHON -m pip install twine  --upgrade
 $PYTHON -m pip install pytest  --upgrade
+$PYTHON -m pip install matplotlib  --upgrade
 
 PLATFORM=$($PYTHON -c "import distutils.util; print(distutils.util.get_platform())")
 

--- a/scripts/get_version.sh
+++ b/scripts/get_version.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-# +(git hash) is not supported by PyPi.
-# echo "3.0.dev$(date +%Y%m%d)+$(git rev-parse --short HEAD)"
-echo "2.63a0.dev$(date +%Y%m%d)"


### PR DESCRIPTION
The build system was setting the version string wrong. Month and dates were swapped in Windows and Unix build. The wheels were uploaded to different versions.

This fixes it. Also, the SMODYN_VERSION is generated at one and only one place (main `CMakeLists.txt`). Before, for UNIX platform, a bash script was used which is now removed. 