### PR TITLE
developer API is not imported by default

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -33,10 +33,13 @@ foreach(_example ${PY_FILES})
     add_dependencies(pyexamples py${_ex_name})
 
     # add to ctest as well.
-    add_test(NAME test_${_ex_name} 
+    add_test(NAME example_${_ex_name} 
         COMMAND ${Python3_EXECUTABLE} ${PYSCRIPT_RUN_WITH_TIMEOUT} ${_example})
 
-    set_tests_properties(test_${_ex_name} PROPERTIES 
+    # MPLBACKEND=agg : makes sure that X11 is not needed while testing on CI.
+    # SMOLDYN_NO_PROMPT=1 : makes sure that shiftQ is not needed to be pressed by
+    # anyone at the end of simulation.
+    set_tests_properties(example_${_ex_name} PROPERTIES 
             ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/py;MPLBACKEND=agg;SMOLDYN_NO_PROMPT=1")
 
 endforeach()

--- a/examples/S6_commands/cmddata.py
+++ b/examples/S6_commands/cmddata.py
@@ -1,6 +1,6 @@
 # Python version of cmddata.txt
 
-import smoldyn 
+import smoldyn
 
 s = smoldyn.Simulation(low=[0, 0, 0], high=[100, 100, 100])
 
@@ -12,15 +12,15 @@ r1 = s.addReaction("r1", subs=[R], prds=[], rate=0.1 )
 R.addToSolution(400)
 B.addToSolution(1, pos=[50,50,50])
 
-smoldyn.addOutputData('mydata')
+s.addOutputData('mydata')
 s.addCommand(cmd="molcount mydata", cmd_type="E")
 
 # Graphics need to be commented out for the plotting to work
 # s.setGraphics( "opengl" )
 
-s = s.run(stop=20, dt=0.01)
+s.run(stop=20, dt=0.01)
 
-data = smoldyn.getOutputData('mydata', 0)
+data = s.getOutputData('mydata', 0)
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/S8_reactions/bounce/cluster.py
+++ b/examples/S8_reactions/bounce/cluster.py
@@ -15,7 +15,7 @@ red.addToSolution(1,pos=[0,0,0])
 rxn = s.addReaction(name='stick',subs=[blue,red],prds=[red,red], rate=20)
 rxn.productPlacement(method='bounce', param=0.6)
 
-smoldyn.addOutputData('counts')
+s.addOutputData('counts')
 s.addCommand(cmd="molcount counts", cmd_type="E")
 
 s.setGraphics('opengl_good',1)
@@ -25,7 +25,7 @@ s.run(200, dt=0.1)
 import matplotlib.pyplot as plt
 import numpy as np
 
-data = smoldyn.getOutputData('counts', 0)
+data = s.getOutputData('counts', 0)
 
 dataT = np.array(data).T.tolist()
 plt.plot(dataT[0],dataT[2],"r")

--- a/examples/S8_reactions/zeroreact/zeroreact.py
+++ b/examples/S8_reactions/zeroreact/zeroreact.py
@@ -1,5 +1,5 @@
 # Zeroth order reactions
-import smoldyn 
+import smoldyn
 
 s = smoldyn.Simulation(low=[0, 0, 0], high=(10, 10, 10), boundary_type="r")
 red = s.addSpecies("red", difc=1, color=[1, 0, 0])
@@ -12,4 +12,4 @@ fast = s.addReaction("fast", [], [blue], rate=0.1)
 s.setGraphics("opengl")
 s.setOutputFile("zeroreactout.txt")
 s.addCommand("molcount zeroreactout.txt", cmd_type="e")
-s = s.run(stop=10, dt=0.01, output_files=["zeroreactout.txt"])
+s = s.run(stop=10, dt=0.01, overwrite=True)

--- a/source/libSteve/SimCommand.c
+++ b/source/libSteve/SimCommand.c
@@ -767,7 +767,7 @@ int scmdopenfiles(cmdssptr cmds,int overwrite) {
 #ifdef COMPILE_AS_PY_MODULE
 					// When built as a python module. There is no way to use scanf (probably)?
 					fprintf(stderr, "File '%s' already exists. Refusing to overwrite.\n", cmds->fname[fid]);
-					fprintf(stderr, "Tip: Set `overwrite=True` in `setOutputFile` method.\n");
+					fprintf(stderr, "Tip: pass `overwrite=True` to `run()` method.\n");
 					return 1;
 #else
 					// When compiled for c++ binary.

--- a/source/python/smoldyn/__init__.py
+++ b/source/python/smoldyn/__init__.py
@@ -1,7 +1,9 @@
 """smoldyn
 
 Python bindings of Smoldyn simulator..
+
+To access the developer Python's API, use `import smoldyn._smodlyn`
 """
-# Bring low-level c-api to the front.
-from smoldyn._smoldyn import *                        # type: ignore
+
+"""Bring symbols from User API (smoldyn.py) to top-level."""
 from smoldyn.smoldyn import *

--- a/source/python/smoldyn/smoldyn.py
+++ b/source/python/smoldyn/smoldyn.py
@@ -2,9 +2,7 @@
 """
 
 __author__ = "Dilawar Singh"
-__copyright__ = "Copyright 2020-, Dilawar Singh"
-__maintainer__ = "Dilawar Singh"
-__email__ = "dilawars@ncbs.res.in"
+__email__ = "dilawar.s.rajput@gmail.com"
 
 __all__ = [
     "__version__",
@@ -40,13 +38,15 @@ from dataclasses import dataclass, field
 from typing import Union, Tuple, List, Dict, Optional, Sequence
 
 import logging
-import inspect
 
 from smoldyn.types import Color, BoundType, ColorType, DiffConst
 from smoldyn import _smoldyn
 
-#: model file. There does not look like a beter way to find this name without
-# asking the user.
+# Path of model file.
+# It does not look like there is a beter way to find this path out
+# automatically. This is needed by simptr.
+import inspect
+
 __top_model_file__ = Path(inspect.stack()[-1].filename)
 
 # Logger
@@ -1798,9 +1798,8 @@ class Simulation(object):
         """Note: One can also set SMOLDYN_NO_PROMPT to achieve the same
         effect."""
 
-        if kwargs.get('seed', -1) >= 0:
-            self.randomSeed = int(kwargs['seed'])
-
+        if kwargs.get("seed", -1) >= 0:
+            self.randomSeed = int(kwargs["seed"])
 
     def setOutputFiles(self, outfiles: List[str], append=True):
         """Declaration of filenames that can be used for output of simulation
@@ -2266,6 +2265,44 @@ class Simulation(object):
     ):
         return Compartment(name, surface=surface, point=point)
 
+    def addOutputData(self, dataname: str) -> None:
+        """Declares the data table called `dataname`, enabling output into it by
+        one or more runtime commands. Spaces are not permitted in the dataname.
+
+        Parameters
+        ----------
+        dataname : str
+            dataname (spaces are not allowed)
+
+        Returns
+        -------
+        None
+
+        """
+        assert " " not in dataname, f"spaces not allowed in dataname: '{dataname}'"
+        r = _smoldyn.addOutputData(dataname)
+        assert r == _smoldyn.ErrorCode.ok, f"Failed to add output data {r}"
+
+    def getOutputData(self, dataname: str, erase: bool = True) -> List[List[float]]:
+        """Returns data that have been recorded by an observation command (e.g. molcount).
+
+        Parameters
+        ----------
+        dataname : str
+            dataname
+
+        erase: bool
+            When set to `True`, the original data is cleared after a copy  of data
+            is returned to the user.
+
+        Returns
+        -------
+        List[List[float]]
+            A matrix of float.
+        """
+        assert " " not in dataname, f"Must not contain spaces: '{dataname}'"
+        return _smoldyn.getOutputData(dataname, erase)
+
     def connect(self, func, target, step: int, args: List[float] = []):
         """Connect a arbitrary Python function to Simulation. The function will
         be called at every 'step'
@@ -2319,4 +2356,3 @@ class Simulation(object):
          (91.0, 0.37011200572554614)]
         """
         return _smoldyn.connect(func, target, step, args)
-

--- a/tests/test_data_in_array.py
+++ b/tests/test_data_in_array.py
@@ -2,7 +2,7 @@
 # Author: Steve
 # Modified by: Dilawar
 
-import smoldyn 
+import smoldyn
 import math
 
 
@@ -23,11 +23,11 @@ def test_data():
 
     R.addToSolution(400)
     B.addToSolution(1, pos=[50,50,50])
-    smoldyn.addOutputData('mydata')
+    s.addOutputData('mydata')
     s.addCommand(cmd="molcount mydata", cmd_type="E")
     # s.setGraphics( "opengl" )
-    s = s.run(stop=10, dt=0.01)
-    data = smoldyn.getOutputData('mydata', 0)
+    s.run(stop=10, dt=0.01)
+    data = s.getOutputData('mydata', 0)
     assert len(data) == 1001, len(data)
     assert len(data[0]) == 3, len(data[0])
     assert data[0] == [0.0, 400.0, 1.0], data[0]

--- a/tests/test_libsmoldyn.py
+++ b/tests/test_libsmoldyn.py
@@ -1,53 +1,55 @@
-__author__           = "Dilawar Singh"
-__copyright__        = "Copyright 2019-, Dilawar Singh"
-__maintainer__       = "Dilawar Singh"
-__email__            = "dilawars@ncbS.reS.in"
+"""Some tests for CPP API.
 
-# Test only extension module.
-import smoldyn as S
+"""
+
+__author__           = "Dilawar Singh"
+__email__            = "dilawars@ncbs.res.in"
+
+# Test only the extension module. It has to be imported by the user.
+import smoldyn._smoldyn as CppApi
 
 def test_library():
     """We test the C API here
     """
-    S.setBoundaries(([-50, 50], [-50, 50]))
-    assert S.getDim() == 2
-    S.setRandomSeed(1)
-    print('Bounds', S.getBoundaries())
+    CppApi.setBoundaries(([-50, 50], [-50, 50]))
+    assert CppApi.getDim() == 2
+    CppApi.setRandomSeed(1)
+    print('Bounds', CppApi.getBoundaries())
 
-    S.setPartitions("molperbox", 4);
-    S.setPartitions("boxsize", 12.5);
+    CppApi.setPartitions("molperbox", 4);
+    CppApi.setPartitions("boxsize", 12.5);
 
-    S.addSpecies("ACA")
-    S.addSpecies("ATP")
-    S.addSpecies("cAMP")
-    S.addSpecies("cAR1")
+    CppApi.addSpecies("ACA")
+    CppApi.addSpecies("ATP")
+    CppApi.addSpecies("cAMP")
+    CppApi.addSpecies("cAR1")
 
-    MS = S.MolecState     # enum MolcState
-    SA = S.SrfAction      # enum SrfAction
-    PF = S.PanelFace      # enum PanelFace
-    PS = S.PanelShape     # enum PanelShape
+    MS = CppApi.MolecState     # enum MolcState
+    SA = CppApi.SrfAction      # enum SrfAction
+    PF = CppApi.PanelFace      # enum PanelFace
+    PS = CppApi.PanelShape     # enum PanelShape
 
-    S.setSpeciesMobility("ACA", MS.all, 1.0)
-    S.setSpeciesMobility("ATP", MS.all, 1.0)
-    S.setSpeciesMobility("cAMP", MS.all, 1.0)
-    S.setSpeciesMobility("cAR1", MS.all, 1.0)
+    CppApi.setSpeciesMobility("ACA", MS.all, 1.0)
+    CppApi.setSpeciesMobility("ATP", MS.all, 1.0)
+    CppApi.setSpeciesMobility("cAMP", MS.all, 1.0)
+    CppApi.setSpeciesMobility("cAR1", MS.all, 1.0)
 
     # Adding surface.
-    S.addSurface("Membrane00")
-    S.setSurfaceAction("Membrane00", PF.both, "ATP", MS.soln, SA.reflect,"")
+    CppApi.addSurface("Membrane00")
+    CppApi.setSurfaceAction("Membrane00", PF.both, "ATP", MS.soln, SA.reflect,"")
 
     params = [-20.0, 20.0, 10.0, 20.0, 20.0]
-    S.addPanel("Membrane00", PS.sph, "", "", params)
+    CppApi.addPanel("Membrane00", PS.sph, "", "", params)
 
-    S.addCompartment("Cell00")
-    S.addCompartmentSurface("Cell00", "Membrane00")
-    S.addCompartmentPoint("Cell00", params)
-    S.addSurfaceMolecules("ACA", MS.down, 30, "Membrane00", PS.all, "all", [])
-    S.addSurfaceMolecules("cAR1", MS.up, 30, "Membrane00", PS.all, "all", [])
-    S.addReaction("r100", "", MS.all, "", MS.all, ["ATP"], [MS.soln], 0.02)
-    S.setReactionRegion("r100", "Cell00", "");
+    CppApi.addCompartment("Cell00")
+    CppApi.addCompartmentSurface("Cell00", "Membrane00")
+    CppApi.addCompartmentPoint("Cell00", params)
+    CppApi.addSurfaceMolecules("ACA", MS.down, 30, "Membrane00", PS.all, "all", [])
+    CppApi.addSurfaceMolecules("cAR1", MS.up, 30, "Membrane00", PS.all, "all", [])
+    CppApi.addReaction("r100", "", MS.all, "", MS.all, ["ATP"], [MS.soln], 0.02)
+    CppApi.setReactionRegion("r100", "Cell00", "");
 
-    S.run(200, dt=0.01, display=True)
+    CppApi.run(200, dt=0.01, display=True)
 
 
 def main():


### PR DESCRIPTION
The C++/C Api symbols are not imported by default anymore (i.e. removed `from smoldyn._smoldyn import *` from `__init__.py` file).

`addOutputData` and `getOutputData` are added to the `Simulation` class as well.