### PR TITLE
Run CI when a release is tagged.

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -2,9 +2,13 @@ name: OSX Build
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+    tags:
+      - '*'
   pull_request:
-    branches: [ master ]
+    branches: 
+      - master
 
 jobs:
   build:

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     tags:
-      - '*'
+      - 'v**'
   pull_request:
     branches: 
       - master

--- a/.github/workflows/wheels_linux.yml
+++ b/.github/workflows/wheels_linux.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     tags:
-      - '*'
+      - 'v**'
   pull_request:
     branches: 
       - master

--- a/.github/workflows/wheels_linux.yml
+++ b/.github/workflows/wheels_linux.yml
@@ -1,9 +1,14 @@
 name: Linux Wheels
+
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+    tags:
+      - '*'
   pull_request:
-    branches: [ master ]
+    branches: 
+      - master
       
 jobs:
   wheel:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,9 +1,15 @@
 name: Windows Build
+
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+    tags:
+      - '*'
   pull_request:
-    branches: [ master ]
+    branches: 
+      - master
+      
 jobs:
   build:
     runs-on: windows-latest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     tags:
-      - '*'
+      - 'v**'
   pull_request:
     branches: 
       - master


### PR DESCRIPTION
Followup on #49 and #50.

Now github actions run when a release is tagged. Only tags which starts with `v` are built and released. It seems to be working fine on my fork (e.g. https://github.com/dilawar/Smoldyn/actions/runs/714581657). Hopefully this will work fine when a new tag is created or an old tag is updated. Try deleting and recreating the v2.64.2 and see if PyPI badge shows version 2.64.2 in the badge after successful built.

