### PR TITLE
`Simulation` object from model file 

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -2,9 +2,13 @@ name: OSX Build
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+    tags:
+      - '*'
   pull_request:
-    branches: [ master ]
+    branches: 
+      - master
 
 jobs:
   build:

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     tags:
-      - '*'
+      - 'v**'
   pull_request:
     branches: 
       - master

--- a/.github/workflows/wheels_linux.yml
+++ b/.github/workflows/wheels_linux.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     tags:
-      - '*'
+      - 'v**'
   pull_request:
     branches: 
       - master

--- a/.github/workflows/wheels_linux.yml
+++ b/.github/workflows/wheels_linux.yml
@@ -1,9 +1,14 @@
 name: Linux Wheels
+
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+    tags:
+      - '*'
   pull_request:
-    branches: [ master ]
+    branches: 
+      - master
       
 jobs:
   wheel:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,9 +1,15 @@
 name: Windows Build
+
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+    tags:
+      - '*'
   pull_request:
-    branches: [ master ]
+    branches: 
+      - master
+      
 jobs:
   build:
     runs-on: windows-latest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     tags:
-      - '*'
+      - 'v**'
   pull_request:
     branches: 
       - master

--- a/source/python/CMakeLists.txt
+++ b/source/python/CMakeLists.txt
@@ -57,11 +57,12 @@ set_target_properties(_smoldyn PROPERTIES
 set(PY_SMOLDYN_OUTDIR ${CMAKE_BINARY_DIR}/py)
 file(MAKE_DIRECTORY ${PY_SMOLDYN_OUTDIR})
 
-add_custom_command(TARGET _smoldyn POST_BUILD 
-  COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${CMAKE_SOURCE_DIR}/source/python/smoldyn ${PY_SMOLDYN_OUTDIR}/smoldyn
-  COMMENT "Copying python source tree to binary directory"
-  VERBATIM)
+add_custom_target(copy_python_tree ALL 
+    DEPENDS _smoldyn
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${CMAKE_SOURCE_DIR}/source/python/smoldyn ${PY_SMOLDYN_OUTDIR}/smoldyn
+    COMMENT "Copying python source tree to binary directory"
+    VERBATIM)
 
 target_link_libraries(_smoldyn PRIVATE _pysmoldyn)
 

--- a/source/python/Simulation.h
+++ b/source/python/Simulation.h
@@ -26,13 +26,10 @@ using namespace std;
  */
 
 class Simulation {
+
 public:
     Simulation(vector<double>& low, vector<double>& high, vector<string>& boundary_type)
-        : low_(low),
-          high_(high),
-          curtime_(0.0),
-          initDisplay_(false),
-          debug_(false)
+        : low_(low), high_(high), curtime_(0.0), initDisplay_(false), debug_(false)
     {
         assert(low.size() == high.size());
 
@@ -51,11 +48,12 @@ public:
         }
     }
 
-    Simulation(simptr sim)
-        : sim_(sim), initDisplay_(false), debug_(false), curtime_(0.0)
+    // Factory function.
+    Simulation(const char* filepath, const char* flags)
+        : curtime_(0.0), initDisplay_(false), debug_(false)
     {
-        // Just copy the simptr.
-        // FIXME: I am forgetting anything here.
+        auto path = splitPath(string(filepath));
+        sim_ = smolPrepareSimFromFile(path.first.c_str(), path.second.c_str(), flags);
     }
 
     ~Simulation()

--- a/source/python/module.cpp
+++ b/source/python/module.cpp
@@ -27,7 +27,7 @@ using namespace std;
 using namespace pybind11::literals;  // for _a
 
 double r_ = 0.0;
-char tempstring[256];
+char   tempstring[256];
 
 /* --------------------------------------------------------------------------*/
 /**
@@ -383,6 +383,8 @@ PYBIND11_MODULE(_smoldyn, m)
      */
     py::class_<Simulation>(m, "Simulation")
     .def(py::init<vector<double> &, vector<double> &, vector<string> &>())
+    .def(py::init<const char*, const char*>())
+
     // Connect a python callback function.
     .def("connect", &Simulation::connect)
     // utility functions.
@@ -1167,9 +1169,8 @@ PYBIND11_MODULE(_smoldyn, m)
      *  Errors  *
      ************/
     m.def("setDebugMode", &smolSetDebugMode);
-    m.def("errorCodeToString", [](ErrorCode err) {
-			return smolErrorCodeToString(err,tempstring);
-			});
+    m.def("errorCodeToString",
+        [](ErrorCode err) { return smolErrorCodeToString(err, tempstring); });
 
     /*****************************
      *  Read configuration file  *

--- a/source/python/smoldyn/smoldyn.py
+++ b/source/python/smoldyn/smoldyn.py
@@ -1823,6 +1823,23 @@ class Simulation(_smoldyn.Simulation):
         if log_level <= 0:
             self.simptr.flag = self.simptr.flag + "q"
 
+    @classmethod
+    def fromFile(cls, path: Union[Path, str], arg: str = ""):
+        """Create `_smoldyn.Simulation` object from model file.
+
+        Parameters
+        ----------
+        path : T.Union[Path, str]
+            path
+        arg : str
+            arg
+        """
+        #  return _smoldyn.Simulation(str(path), arg)
+        obj = cls.__new__(cls)
+        super(Simulation, obj).__init__(str(path), arg)
+        obj.simptr = obj.getSimPtr()
+        return obj
+
     def setOutputFiles(self, outfiles: List[str], append=True):
         """Declaration of filenames that can be used for output of simulation
         results.  Spaces are not permitted in these names.  Any previous files

--- a/tests/test_sim_from_file.py
+++ b/tests/test_sim_from_file.py
@@ -3,7 +3,36 @@ __email__ = "dilawar@subcom.tech"
 
 from pathlib import Path
 
+import smoldyn
+import smoldyn._smoldyn as S
+
 sdir = Path(__file__).parent
 
-if __name__ == '__main__':
+
+def test_simptr_simobj():
+    s1 = smoldyn.Simulation([0, 0], [10, 10])
+    assert(s1)
+    assert(s1.getSimPtr())
+    assert(s1.simptr)
+    print(s1)
+    print(s1.getSimPtr())
+    modelfile = sdir / ".." / "examples" / "S99_more" / "Min" / "Min1.txt"
+
+    #  s2 = S.Simulation(str(modelfile), "")  # type: _smoldyn.Simulation 
+    # or, recommended.
+    s2 = smoldyn.Simulation.fromFile(modelfile, "")   # type: Simulation 
+    assert s2
+    assert s2.getSimPtr()
+    #  assert s2.simptr
+
+    print(s2)
+    print(s2.getSimPtr())
+    #  print(s2.simptr)
+
+
+def main():
+    test_simptr_simobj()
+
+
+if __name__ == "__main__":
     main()

--- a/tests/test_sim_from_file.py
+++ b/tests/test_sim_from_file.py
@@ -1,0 +1,9 @@
+__author__ = "Dilawar Singh"
+__email__ = "dilawar@subcom.tech"
+
+from pathlib import Path
+
+sdir = Path(__file__).parent
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_sim_from_file.py
+++ b/tests/test_sim_from_file.py
@@ -11,16 +11,16 @@ sdir = Path(__file__).parent
 
 def test_simptr_simobj():
     s1 = smoldyn.Simulation([0, 0], [10, 10])
-    assert(s1)
-    assert(s1.getSimPtr())
-    assert(s1.simptr)
+    assert s1
+    assert s1.getSimPtr()
+    assert s1.simptr
     print(s1)
     print(s1.getSimPtr())
     modelfile = sdir / ".." / "examples" / "S99_more" / "Min" / "Min1.txt"
 
-    #  s2 = S.Simulation(str(modelfile), "")  # type: _smoldyn.Simulation 
+    #  s2 = S.Simulation(str(modelfile), "")  # type: _smoldyn.Simulation
     # or, recommended.
-    s2 = smoldyn.Simulation.fromFile(modelfile, "")   # type: Simulation 
+    s2 = smoldyn.Simulation.fromFile(modelfile, "")  # type: Simulation
     assert s2
     assert s2.getSimPtr()
     #  assert s2.simptr
@@ -30,9 +30,5 @@ def test_simptr_simobj():
     #  print(s2.simptr)
 
 
-def main():
-    test_simptr_simobj()
-
-
 if __name__ == "__main__":
-    main()
+    test_simptr_simobj()


### PR DESCRIPTION
Following is possible.  Also see file `tests/test_sim_from_file.py`. This PR also contains #51 .

```python 
import smoldyn
import smoldyn._smoldyn as S

s1 = smoldyn.Simulation([0, 0], [10, 10])
assert(s1)
assert(s1.getSimPtr())
assert(s1.simptr)
print(s1)
print(s1.getSimPtr())

#  s2 = S.Simulation("Min1.txt", "")  # type: _smoldyn.Simulation 
# or, recommended.
s2 = smoldyn.Simulation.fromFile("Min1.txt", "")   # type: Simulation 
assert s2
assert s2.getSimPtr()
#  assert s2.simptr
print(s2)
print(s2.getSimPtr())
#  print(s2.simptr)
```

This is preferred over the following

```
>>> sptr =S.prepareSimFromFile("Min1.txt","")
>>> s2 = smoldyn.Simulation.fromSimptr(sptr)
```
which often leads to `double free` error. Because I implemented `fromSimptr` as a `static` method in C++ class Simulation that return a `Simulation` object. The destructor was called twice. Not sure if that was due to mixing static factory method with normal constructors and the way pybind11 handles them together or something else. I didn't dig deeper because this design looked better to me.  
