### PR TITLE
Fixes to script.

### DIFF
--- a/examples/S15_python/SearchOptimize.py
+++ b/examples/S15_python/SearchOptimize.py
@@ -33,7 +33,8 @@ best = 1000
 oldvalue = value
 for it in range(10):
 	value += sigma * (numpy.random.randint(2)-0.5)
-	S.Simulation.setSurfaceRate(s, "membrane" ,"protein", "soln", "bsoln", "back", value, "protein", False)
+        # also see smoldyn.Simulation.setRate function.
+	S.Simulation.setSurfaceRate(s, "membrane" ,"protein", S.MolecState.soln,S.MolecState.bsoln, S.MolecState.back, value, "protein", False)
 	s.run(stop=100,dt=0.01)
 	data=s.getOutputData("output",0)
 	test=data[0][0]


### PR DESCRIPTION
Fixes to new script. The C++ Api expects `_smoldyn.MolecState` e.g. `_smoldyn.MolecState.back` rather than string `"back"`. Also see function `setRate` in Python API where string values such as "front", "back" etc. are converted to `_smoldyn.MolecState` by `_toMS` function. 