### PR TITLE
Minor tweaks to github actions

### DIFF
--- a/.github/workflows/wheels_linux.yml
+++ b/.github/workflows/wheels_linux.yml
@@ -7,9 +7,9 @@ on:
     tags:
       - 'v**'
   pull_request:
-    branches: 
+    branches:
       - master
-      
+
   workflow_dispatch:
 
 jobs:
@@ -52,6 +52,7 @@ jobs:
       - name: Push BioSimulators Docker image
         env:
           TAG: ${{ github.ref }}
+          SECRETS_ARE_AVAILABLE: ${{ secrets.BIOSIMULATORS_GH_TOKEN }}
         run: |
           cd scripts
           if [[ "${TAG}" =~ ^refs/tags/ ]]; then
@@ -60,16 +61,22 @@ jobs:
             WHEEL_PATH=$(ls smoldyn*.whl)
             VERSION=$(echo $WHEEL_PATH | cut -d - -f 2- | cut -d . -f 1-2)
           fi
-          docker login ghcr.io \
-            --username ${{ secrets.BIOSIMULATORS_GH_USERNAME }} \
-            --password ${{ secrets.BIOSIMULATORS_GH_TOKEN }}
-          docker push ghcr.io/ssandrews/smoldyn/biosimulators_smoldyn:${VERSION}
-          docker push ghcr.io/ssandrews/smoldyn/biosimulators_smoldyn:latest
+
+          if [ -z ${SECRETS_ARE_AVAILABLE+x} ]; then
+              docker login ghcr.io \
+                --username ${{ secrets.BIOSIMULATORS_GH_USERNAME }} \
+                --password ${{ secrets.BIOSIMULATORS_GH_TOKEN }}
+              docker push ghcr.io/ssandrews/smoldyn/biosimulators_smoldyn:${VERSION}
+              docker push ghcr.io/ssandrews/smoldyn/biosimulators_smoldyn:latest
+          else
+            echo "GH_TOKEN are not set. Not uploading docker image"
+          fi
 
       - name: Submit Smoldyn to BioSimulators
         if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         env:
           TAG: ${{ github.ref }}
+          SECRETS_ARE_AVAILABLE: ${{ secrets.BIOSIMULATORS_GH_TOKEN }}
         run: |
           cd scripts
           if [[ "${TAG}" =~ ^refs/tags/ ]]; then
@@ -79,9 +86,13 @@ jobs:
             VERSION=$(echo $WHEEL_PATH | cut -d - -f 2- | cut -d . -f 1-2)
           fi
           REVISION=$(git rev-parse HEAD)
-          curl \
-            -X POST \
-            -u ${{ secrets.BIOSIMULATORS_GH_USERNAME }}:${{ secrets.BIOSIMULATORS_GH_TOKEN }} \
-            -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/biosimulators/Biosimulators/issues \
-            -d "{\"labels\": [\"Validate/submit simulator\"], \"title\": \"Submit Smoldyn ${VERSION}\", \"body\": \"---\nid: smoldyn\nversion: ${VERSION}\nspecificationsUrl: https://raw.githubusercontent.com/ssandrews/Smoldyn/${REVISION}/biosimulators.json\nspecificationsPatch:\n  version: ${VERSION}\n  image:\n    url: ghcr.io/ssandrews/smoldyn/biosimulators_smoldyn:${VERSION}\nvalidateImage: true\ncommitSimulator: true\n\n---\"}"
+          if [ -z ${SECRETS_ARE_AVAILABLE+x} ]; then
+              curl \
+                -X POST \
+                -u ${{ secrets.BIOSIMULATORS_GH_USERNAME }}:${{ secrets.BIOSIMULATORS_GH_TOKEN }} \
+                -H "Accept: application/vnd.github.v3+json" \
+                https://api.github.com/repos/biosimulators/Biosimulators/issues \
+                -d "{\"labels\": [\"Validate/submit simulator\"], \"title\": \"Submit Smoldyn ${VERSION}\", \"body\": \"---\nid: smoldyn\nversion: ${VERSION}\nspecificationsUrl: https://raw.githubusercontent.com/ssandrews/Smoldyn/${REVISION}/biosimulators.json\nspecificationsPatch:\n  version: ${VERSION}\n  image:\n    url: ghcr.io/ssandrews/smoldyn/biosimulators_smoldyn:${VERSION}\nvalidateImage: true\ncommitSimulator: true\n\n---\"}"
+            else
+                echo "Secrets are not available. Not creating issue."
+            fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ if(NOT SMOLDYN_VERSION)
         else()
             # nightly release.
             string(TIMESTAMP STAMP "%Y%m%d")
-            set(SMOLDYN_VERSION "2.65.dev${STAMP}")
+            set(SMOLDYN_VERSION "2.66.dev${STAMP}")
         endif()
     endif()
 endif()
@@ -467,6 +467,7 @@ add_subdirectory(source/libSteve)
 add_library(smoldyn_static STATIC ${SRC_FILES}
     $<TARGET_OBJECTS:Steve>
     $<TARGET_OBJECTS:nsv>)
+
 set_property(TARGET smoldyn_static PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(smoldyn_static PUBLIC ${DEP_LIBS})
 set_target_properties(smoldyn_static PROPERTIES PREFIX "lib")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 # Please report bugs and problems to support@smoldyn.org.
 
 ########## Basic setup ##########
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.14)
 
 project(smoldyn LANGUAGES CXX C)
 
@@ -105,7 +105,6 @@ message(STATUS "Option to build documentation: ${OPTION_DOCS}")
 # NOTE: C++17 has parallel implmenetation of many STL algorithms. It would be
 # nice to use them. Most compilers support C++17 these days.
 #
-set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_C_STANDARD 11)
 
 include(CheckCCompilerFlag)
@@ -127,13 +126,13 @@ function(CheckCompilerFlagAndAdd)
     endif()
 endfunction()
 
-# enable all warnings.
 if(MSVC)
     # FIXME: On Windows, when using MSVC, reduce the amount of warnings. MSVC
     # generates a lot of warning about casting which pollute the build log and
     # makes it hard to find the error.
     add_compile_options(/W1)
 else()
+    # enable all warnings.
     add_compile_options(-Wall -Wextra)
     CheckCompilerFlagAndAdd(-Wno-unused-parameter)
 endif()
@@ -152,13 +151,22 @@ if(OPTION_STRICT_BUILD)
     CheckCompilerFlagAndAdd(-Wno-unused-but-set-parameter)
 endif()
 
-# For CI.
-if(WIN32) # AND "$ENV{GITHUB_ACTIONS}")
-    message(STATUS "Running github actions on Window platform")
-    set(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION 10.0.19041)
-    include(cmake/GithubActions.cmake)
+# We need a c++14 support to build python bindings.
+if(OPTION_PYTHON)
+    set(CMAKE_CXX_STANDARD 14)
+    try_compile(COMPILER_SUPPORT_C14
+        ${CMAKE_BINARY_DIR}/_test_compiler
+        ${CMAKE_CURRENT_SOURCE_DIR}/cmake/test_compiler.cpp
+        OUTPUT_VARIABLE COMPILER_TEST_OUTPUT
+        )
+    if(NOT COMPILER_SUPPORT_C14)
+        message(STATUS "Failed to build test program: ${COMPILER_TEST_OUTPUT}")
+        message(FATAL_ERROR "Your compiler does not support C++14. "
+            "Please use a C++14 compliant compiler. "
+            "See https://en.cppreference.com/w/cpp/compiler_support/14 "
+            "for C++14 support among C++ compilers.")
+    endif()
 endif()
-
 
 
 ######### Core code information ###########

--- a/cmake/test_compiler.cpp
+++ b/cmake/test_compiler.cpp
@@ -1,0 +1,16 @@
+/*
+ * A simple program to check if compiler has C++14 support.
+ */
+
+#include <memory>
+
+struct MyStruct {
+    int a;
+    int b;
+};
+
+int main() {
+    auto a = std::make_unique<int>(1);
+    auto b = std::make_unique<MyStruct>();
+    return 0;
+}

--- a/scripts/build_wheels_osx.sh
+++ b/scripts/build_wheels_osx.sh
@@ -60,10 +60,19 @@ PLATFORM=$($PYTHON -c "import distutils.util; print(distutils.util.get_platform(
         # which python
         # now use venv pyhton.
         $PYTHON --version
-        $PYTHON -m pip install $WHEELHOUSE/smoldyn*.whl
-        $PYTHON -c 'import smoldyn; print(smoldyn.__version__ )'
-        $PYTHON -m pip uninstall -y smoldyn
+
+        # Use the latest wheel. There could be more than one whl files in
+        # WHEELHOUSE (sometimes, on github actions for sure).
+        WHEELFILE=$(ls -t "$WHEELHOUSE"/smoldyn*.whl | head -n 1)
+        if [ -f "${WHEELFILE}" ]; then
+            $PYTHON -m pip install "$WHEELFILE"
+            $PYTHON -c 'import smoldyn; print(smoldyn.__version__ )'
+            $PYTHON -m pip uninstall -y smoldyn
+        else
+            echo "Strage! No wheel is found."
+        fi
     )
+
 )
 
 if [ -n "$PYPI_PASSWORD" ]; then

--- a/source/python/CallbackFunc.cpp
+++ b/source/python/CallbackFunc.cpp
@@ -17,8 +17,7 @@
 namespace py = pybind11;
 
 CallbackFunc::CallbackFunc()
-  : val_(0.0)
-  , funcName_("")
+  : funcName_("")
   , func_(py::none())
   , step_(1)
   , args_({})
@@ -43,8 +42,7 @@ CallbackFunc::evalAndUpdate(double t)
     if (true == py::isinstance<py::function>(target_))
         target_(v);
     else
-        py::exec(target_.cast<string>() + '=' + std::to_string(v),
-                 m.attr("__dict__"));
+        py::exec(target_.cast<string>() + '=' + std::to_string(v), m.attr("__dict__"));
     return true;
 }
 

--- a/source/python/CallbackFunc.h
+++ b/source/python/CallbackFunc.h
@@ -17,7 +17,7 @@ namespace py = pybind11;
 
 using namespace std;
 
-class CallbackFunc
+class __attribute__((visibility("hidden"))) CallbackFunc
 {
   public:
     CallbackFunc();
@@ -43,7 +43,6 @@ class CallbackFunc
 
   private:
     /* data */
-    double val_;
     std::string funcName_;
     py::function func_;
     size_t step_;

--- a/source/python/CallbackFunc.h
+++ b/source/python/CallbackFunc.h
@@ -17,7 +17,7 @@ namespace py = pybind11;
 
 using namespace std;
 
-class __attribute__((visibility("hidden"))) CallbackFunc
+class CallbackFunc
 {
   public:
     CallbackFunc();


### PR DESCRIPTION
- Tweaks to GitHub actions to make sure that they pass on forks. On forks, SECRETS are not set. If secrets are not set, do not run part of the actions that depend on them.
- Current development version on the main branch is bumped to 2.66.dev
- Added a compiler check. cmake tries to build `cmake/test_compiler.cpp` program first only when `OPTION_PYTHON` is `ON`.