### PR TITLE
getError and `count` function are added

### DIFF
--- a/examples/S15_python/intersurface.py
+++ b/examples/S15_python/intersurface.py
@@ -1,46 +1,66 @@
 # Bimolecular reactions between molecules on different surfaces
 
 __author__ = "Dilawar Singh"
-__email__ = "dilawars@ncbs.res.in"
+__email__ = "dilawar.s.rajput@gmail.com"
 
 import smoldyn
 
-s = smoldyn.Simulation(low=[0, 0], high=[100, 100], types="r")
-A = s.addSpecies("A", color={"all": "red"}, difc={"all": 1}, display_size=dict(all=1))
-B = s.addSpecies("B", color={"all": "green"}, difc={"all": 1}, display_size=dict(all=1))
-C = s.addSpecies("C", color={"all": "blue"}, difc={"all": 1}, display_size=dict(all=1))
 
-p1 = smoldyn.Rectangle(corner=(0, 0), dimensions=[100], axis="+x")
-p2 = smoldyn.Rectangle(corner=(100, 0), dimensions=[100], axis="-x")
-p3 = smoldyn.Rectangle(corner=(0, 0), dimensions=[100], axis="+y")
-p4 = smoldyn.Rectangle(corner=(0, 100), dimensions=[100], axis="-y")
-walls = s.addSurface("walls", panels=[p1, p2, p3, p4])
-walls.setAction('both', [A, B, C], "reflect")
+def test_getters():
+    s = smoldyn.Simulation(low=[0, 0], high=[100, 100], types="r")
+    A = s.addSpecies(
+        "A", color={"all": "red"}, difc={"all": 1}, display_size=dict(all=1)
+    )
+    B = s.addSpecies(
+        "B", color={"all": "green"}, difc={"all": 1}, display_size=dict(all=1)
+    )
+    C = s.addSpecies(
+        "C", color={"all": "blue"}, difc={"all": 1}, display_size=dict(all=1)
+    )
 
-r1 = smoldyn.Rectangle(corner=[49, 30], dimensions=[20], axis="+x", name="r1")
-t1 = smoldyn.Triangle(vertices=[[49, 50], [29, 70]], name="t1")
-left = s.addSurface(name="left", panels=[r1, t1])
+    p1 = smoldyn.Rectangle(corner=(0, 0), dimensions=[100], axis="+x")
+    p2 = smoldyn.Rectangle(corner=(100, 0), dimensions=[100], axis="-x")
+    p3 = smoldyn.Rectangle(corner=(0, 0), dimensions=[100], axis="+y")
+    p4 = smoldyn.Rectangle(corner=(0, 100), dimensions=[100], axis="-y")
+    walls = s.addSurface("walls", panels=[p1, p2, p3, p4])
+    walls.setAction("both", [A, B, C], "reflect")
 
-r1.neighbor = t1
-t1.neighbor = r1
-left.setAction('both', [A, B, C], "reflect")
-left.addMolecules((A, "up"), 20)
+    r1 = smoldyn.Rectangle(corner=[49, 30], dimensions=[20], axis="+x", name="r1")
+    t1 = smoldyn.Triangle(vertices=[[49, 50], [29, 70]], name="t1")
+    left = s.addSurface(name="left", panels=[r1, t1])
 
-r1 = smoldyn.Rectangle(corner=[50, 30], dimensions=[20], axis="+x", name="r1")
-t1 = smoldyn.Triangle(vertices=[[50, 30], [70, 10]], name="t1")
-right = s.addSurface(name="right", panels=[r1, t1])
-r1.neighbor = t1
-t1.neighbor = r1
-right.setAction('both', [A, B, C], "reflect")
-right.addMolecules((B, "up"), 20)
+    r1.neighbor = t1
+    t1.neighbor = r1
+    left.setAction("both", [A, B, C], "reflect")
+    left.addMolecules((A, "up"), 20)
 
-rxn1 = s.addReaction(
-    name="rxn1",
-    subs=[(A, "up"), (B, "up")],
-    prds=[(A, "up"), (C, "bsoln")],
-    binding_radius=2,
-)
-rxn1.setIntersurface([1, 1])
+    r1 = smoldyn.Rectangle(corner=[50, 30], dimensions=[20], axis="+x", name="r1")
+    t1 = smoldyn.Triangle(vertices=[[50, 30], [70, 10]], name="t1")
+    right = s.addSurface(name="right", panels=[r1, t1])
+    r1.neighbor = t1
+    t1.neighbor = r1
+    right.setAction("both", [A, B, C], "reflect")
+    right.addMolecules((B, "up"), 20)
 
-s.addGraphics("opengl_good")
-s = s.run(1000, dt=0.1)
+    rxn1 = s.addReaction(
+        name="rxn1",
+        subs=[(A, "up"), (B, "up")],
+        prds=[(A, "up"), (C, "bsoln")],
+        binding_radius=2,
+    )
+    rxn1.setIntersurface([1, 1])
+
+    s.addGraphics("opengl_good")
+
+    c = s.count_all()
+    print(c)
+
+    #s = s.run(1000, dt=0.1)
+
+
+def main():
+    test_getters()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/S15_python/intersurface.py
+++ b/examples/S15_python/intersurface.py
@@ -51,11 +51,7 @@ def test_getters():
     rxn1.setIntersurface([1, 1])
 
     s.addGraphics("opengl_good")
-
-    c = s.count_all()
-    print(c)
-
-    #s = s.run(1000, dt=0.1)
+    s = s.run(1000, dt=0.1)
 
 
 def main():

--- a/source/Smoldyn/smoldyn.h
+++ b/source/Smoldyn/smoldyn.h
@@ -8,14 +8,14 @@
 #ifndef __smoldyn_h__
 #define __smoldyn_h__
 
-#ifdef  __cplusplus
+#ifdef __cplusplus
 
 #ifdef ENABLE_PYTHON_CALLBACK
 #define MAX_PY_CALLBACK 10
 #include "../python/CallbackFunc.h"
 #endif
 
-#endif     // -----  not __CPLUSPLSU  -----
+#endif // -----  not __CPLUSPLSU  -----
 
 #include <stdbool.h>
 #include <stdio.h>
@@ -206,8 +206,8 @@ typedef struct cmdsuperstruct
 #define NSVC_H_
 
 #ifdef NSVC_CPP
-#include <string.h>
 #include "Kairos.h"
+#include <string.h>
 using Kairos::NextSubvolumeMethod;
 
 #if defined(HAVE_VTK)
@@ -751,84 +751,104 @@ typedef struct latticesuperstruct
 
 /********************************* Filaments ********************************/
 
-enum FilamentDynamics {FDnone,FDrigidbeads,FDrigidsegments,FDrouse,FDalberts,FDnedelec};
-enum FilamentBiology {FBactin,FBmicrotubule,FBintermediate,FBdsDNA,FBssDNA,FBother,FBnone};
+enum FilamentDynamics
+{
+    FDnone,
+    FDrigidbeads,
+    FDrigidsegments,
+    FDrouse,
+    FDalberts,
+    FDnedelec
+};
+enum FilamentBiology
+{
+    FBactin,
+    FBmicrotubule,
+    FBintermediate,
+    FBdsDNA,
+    FBssDNA,
+    FBother,
+    FBnone
+};
 
-typedef struct beadstruct {
-	double xyz[3];							// bead coordinates
-	double xyzold[3];						// bead coordinates for prior time
-	} *beadptr;
+typedef struct beadstruct
+{
+    double xyz[3];    // bead coordinates
+    double xyzold[3]; // bead coordinates for prior time
+} * beadptr;
 
-typedef struct segmentstruct {
-	double xyzfront[3];					// Coords. for segment front
-	double xyzback[3];					// Coords. for segment back
-	double len;									// segment length
-	double ypr[3];							// relative ypr angles
-	double dcm[9];							// relative dcm
-	double adcm[9];							// absolute segment orientation
-	double thk;									// thickness of segment
-	} *segmentptr;
+typedef struct segmentstruct
+{
+    double xyzfront[3]; // Coords. for segment front
+    double xyzback[3];  // Coords. for segment back
+    double len;         // segment length
+    double ypr[3];      // relative ypr angles
+    double dcm[9];      // relative dcm
+    double adcm[9];     // absolute segment orientation
+    double thk;         // thickness of segment
+} * segmentptr;
 
-typedef struct filamentstruct {
-	struct filamenttypestruct *filtype;		// filament type structure
-	char *filname;							// filament name (reference, not owned)
-	int maxbs;									// number of beads or segments allocated
-	int nbs;										// number of beads or segments
-	int frontbs;								// index of front bead or segment
-	beadptr *beads;							// array of beads if any
-	segmentptr *segments;				// array of segments if any
-	struct filamentstruct *frontend;	// what front attaches to if anything
-	struct filamentstruct *backend;		// what back attaches to if anything
-	int maxbranch;							// max number of branches off this filament
-	int nbranch;								// number of branches off this filament
-	int *branchspots;						// list of bead or segments where branches are
-	struct filamentstruct **branches;		// list of branching filaments
-	int maxmonomer;							// number of monomers allocated
-	int nmonomer;								// number of monomers
-	int frontmonomer;						// index of front monomer
-	char *monomers;							// monomer codes
-	} *filamentptr;
+typedef struct filamentstruct
+{
+    struct filamenttypestruct* filtype; // filament type structure
+    char* filname;                      // filament name (reference, not owned)
+    int maxbs;                          // number of beads or segments allocated
+    int nbs;                            // number of beads or segments
+    int frontbs;                        // index of front bead or segment
+    beadptr* beads;                     // array of beads if any
+    segmentptr* segments;               // array of segments if any
+    struct filamentstruct* frontend;    // what front attaches to if anything
+    struct filamentstruct* backend;     // what back attaches to if anything
+    int maxbranch;                      // max number of branches off this filament
+    int nbranch;                        // number of branches off this filament
+    int* branchspots;                   // list of bead or segments where branches are
+    struct filamentstruct** branches;   // list of branching filaments
+    int maxmonomer;                     // number of monomers allocated
+    int nmonomer;                       // number of monomers
+    int frontmonomer;                   // index of front monomer
+    char* monomers;                     // monomer codes
+} * filamentptr;
 
-typedef struct filamenttypestruct {
-	struct filamentsuperstruct *filss;	// filament superstructure
-	char *ftname;								// filament type name (reference, not owned)
-	enum FilamentDynamics dynamics;	// dynamics for the filament
-	int isbead;									// 1 for bead model, 0 for segments
-	enum FilamentBiology biology; // Biological name for filament type
-	double bundlevalue;					// number of microfilaments in bundle
-	double color[4];						// filament color
-	double edgepts;							// thickness of edge for drawing
-	unsigned int edgestipple[2];	// edge stippling [factor, pattern]
-	enum DrawMode drawmode;			// polygon drawing mode
-	double shiny;								// shininess
-	double stdlen;							// minimum energy segment length
-	double stdypr[3];						// minimum energy bend angle
-	double klen;								// force constant for length
-	double kypr[3];							// force constant for angle
-	double kT;									// thermodynamic temperature, [0,inf)
-	double treadrate;						// treadmilling rate constant
-	double viscosity;						// viscosity
-	double filradius;						// bead or segment radius
-	int maxface;								// number of filament faces allocated
-	int nface;									// number of filament faces
-	char **facename;						// list of face names
-	double facetwist;						// twisting rate of faces along filament
-	int maxfil;									// maximum number of filaments
-	int nfil;										// actual number of filaments
-	filamentptr *fillist;				// list of filaments
-	char **filnames;						// names of filaments
-} *filamenttypeptr;
+typedef struct filamenttypestruct
+{
+    struct filamentsuperstruct* filss; // filament superstructure
+    char* ftname;                      // filament type name (reference, not owned)
+    enum FilamentDynamics dynamics;    // dynamics for the filament
+    int isbead;                        // 1 for bead model, 0 for segments
+    enum FilamentBiology biology;      // Biological name for filament type
+    double bundlevalue;                // number of microfilaments in bundle
+    double color[4];                   // filament color
+    double edgepts;                    // thickness of edge for drawing
+    unsigned int edgestipple[2];       // edge stippling [factor, pattern]
+    enum DrawMode drawmode;            // polygon drawing mode
+    double shiny;                      // shininess
+    double stdlen;                     // minimum energy segment length
+    double stdypr[3];                  // minimum energy bend angle
+    double klen;                       // force constant for length
+    double kypr[3];                    // force constant for angle
+    double kT;                         // thermodynamic temperature, [0,inf)
+    double treadrate;                  // treadmilling rate constant
+    double viscosity;                  // viscosity
+    double filradius;                  // bead or segment radius
+    int maxface;                       // number of filament faces allocated
+    int nface;                         // number of filament faces
+    char** facename;                   // list of face names
+    double facetwist;                  // twisting rate of faces along filament
+    int maxfil;                        // maximum number of filaments
+    int nfil;                          // actual number of filaments
+    filamentptr* fillist;              // list of filaments
+    char** filnames;                   // names of filaments
+} * filamenttypeptr;
 
-typedef struct filamentsuperstruct {
-	enum StructCond condition;	// structure condition
-	struct simstruct *sim;			// simulation structure
-	int maxtype;								// maximum number of filament types
-	int ntype;									// actual number of filament types
-	char **ftnames;							// filament type names
-	filamenttypeptr *filtypes;	// list of filament types
-	} *filamentssptr;
-
-
+typedef struct filamentsuperstruct
+{
+    enum StructCond condition; // structure condition
+    struct simstruct* sim;     // simulation structure
+    int maxtype;               // maximum number of filament types
+    int ntype;                 // actual number of filament types
+    char** ftnames;            // filament type names
+    filamenttypeptr* filtypes; // list of filament types
+} * filamentssptr;
 
 /* OLD FILAMENTS
 typedef struct filamentstruct
@@ -1018,41 +1038,54 @@ typedef int (*checkwallsfnptr)(struct simstruct*, int, int, boxptr);
 
 typedef struct simstruct
 {
-    enum StructCond condition;                  // structure condition
-    FILE* logfile;                              // file to send output
-    char* filepath;                             // configuration file path
-    char* filename;                             // configuration file name
-    char* flags;                                // command-line options from user
-    time_t clockstt;                            // clock starting time of simulation
-    double elapsedtime;                         // elapsed time of simulation
-    long int randseed;                          // random number generator seed
-    int eventcount[ETMAX];                      // counter for simulation events
-    int maxvar;                                 // allocated user-settable variables
-    int nvar;                                   // number of user-settable variables
-    char** varnames;                            // names of user-settable variables [v]
-    double* varvalues;                          // values of user-settable variables [v]
-    int dim;                                    // dimensionality of space.
-    double accur;                               // accuracy, on scale from 0 to 10
-    double time;                                // current time in simulation
-    double tmin;                                // simulation start time
-    double tmax;                                // simulation end time
-    double tbreak;                              // simulation break time
-    double dt;                                  // simulation time step
-    bool quitatend;                             // simulation quits at the end
-    rxnssptr rxnss[MAXORDER];                   // reaction superstructures
-    rulessptr ruless;                           // rule superstructure
-    molssptr mols;                              // molecule superstructure
-    wallptr* wlist;                             // list of walls
-    surfacessptr srfss;                         // surface superstructure
-    boxssptr boxs;                              // box superstructure
-    compartssptr cmptss;                        // compartment superstructure
-    portssptr portss;                           // port superstructure
-    latticessptr latticess;                     // lattice superstructure
-    bngssptr bngss;                             // bionetget superstructure
-    filamentssptr filss;                        // filament superstructure
-    cmdssptr cmds;                              // command superstructure
-    graphicsssptr graphss;                      // graphics superstructure
-    diffusefnptr diffusefn;                     // function for molecule diffusion
+    enum StructCond condition; // structure condition
+    FILE* logfile;             // file to send output
+    char* filepath;            // configuration file path
+    char* filename;            // configuration file name
+    char* flags;               // command-line options from user
+    time_t clockstt;           // clock starting time of simulation
+    double elapsedtime;        // elapsed time of simulation
+    long int randseed;         // random number generator seed
+    int eventcount[ETMAX];     // counter for simulation events
+    int maxvar;                // allocated user-settable variables
+    int nvar;                  // number of user-settable variables
+    char** varnames;           // names of user-settable variables [v]
+    double* varvalues;         // values of user-settable variables [v]
+
+    int dim; // dimensionality of space.
+
+    double accur;  // accuracy, on scale from 0 to 10
+    double time;   // current time in simulation
+    double tmin;   // simulation start time
+    double tmax;   // simulation end time
+    double tbreak; // simulation break time
+    double dt;     // simulation time step
+
+    bool quitatend; // simulation quits at the end
+
+    rxnssptr rxnss[MAXORDER]; // reaction superstructures
+    rulessptr ruless;         // rule superstructure
+    molssptr mols;            // molecule superstructure
+    wallptr* wlist;           // list of walls
+    surfacessptr srfss;       // surface superstructure
+    boxssptr boxs;            // box superstructure
+
+    compartssptr cmptss; // compartment superstructure
+
+    portssptr portss; // port superstructure
+
+    latticessptr latticess; // lattice superstructure
+
+    bngssptr bngss; // bionetget superstructure
+
+    filamentssptr filss; // filament superstructure
+
+    cmdssptr cmds; // command superstructure
+
+    graphicsssptr graphss; // graphics superstructure
+
+    diffusefnptr diffusefn; // function for molecule diffusion
+
     surfaceboundfnptr surfaceboundfn;           // function for surface-bound molecules
     surfacecollisionsfnptr surfacecollisionsfn; // function for surface collisons
     assignmols2boxesfnptr assignmols2boxesfn;   // function that assigns molecs to boxes
@@ -1066,7 +1099,7 @@ typedef struct simstruct
     CallbackFunc* callbacks[MAX_PY_CALLBACK]; // Python callback.
     unsigned int ncallbacks;                  // number of callbacks.
     size_t simstep;
-#endif   // __cplusplsu
+#endif // __cplusplsu
 #endif
 
 #ifdef OPTION_VCELL
@@ -1142,7 +1175,7 @@ class AbstractMesh
     virtual void getNumXYZ(int* num) = 0;
 };
 
-#endif    // not __cplusplus
+#endif // not __cplusplus
 
 #endif
 

--- a/source/Smoldyn/smolfilament.c
+++ b/source/Smoldyn/smolfilament.c
@@ -1653,20 +1653,21 @@ int filloadtype(simptr sim,ParseFilePtr *pfpptr,char *line2) {
 			firstline2=0; }
 		else
 			pfpcode=Parse_ReadLine(&pfp,word,&line2,errstring);
-			*pfpptr=pfp;
-			CHECKS(pfpcode!=3,"%s",errstring);
 
-			if(pfpcode==0);																// already taken care of
-			else if(pfpcode==2) {													// end reading
-				done=1; }
-			else if(!strcmp(word,"end_filament_type")) {		// end_filament_type
-				CHECKS(!line2,"unexpected text following end_filament_type");
-				return 0; }
-			else if(!line2) {															// just word
-				CHECKS(0,"unknown word or missing parameter"); }
-			else {
-				filtype=filtypereadstring(sim,pfp,filtype,word,line2);
-				CHECK(filtype); }}													// failed but error has already been sent
+        *pfpptr=pfp;
+        CHECKS(pfpcode!=3,"%s",errstring);
+
+        if(pfpcode==0);																// already taken care of
+        else if(pfpcode==2) {													// end reading
+            done=1; }
+        else if(!strcmp(word,"end_filament_type")) {		// end_filament_type
+            CHECKS(!line2,"unexpected text following end_filament_type");
+            return 0; }
+        else if(!line2) {															// just word
+            CHECKS(0,"unknown word or missing parameter"); }
+        else {
+            filtype=filtypereadstring(sim,pfp,filtype,word,line2);
+            CHECK(filtype); }}													// failed but error has already been sent
 
 	CHECKS(0,"end of file encountered before end_filament_type statement");	// end of file
 
@@ -1698,21 +1699,22 @@ int filloadfil(simptr sim,ParseFilePtr *pfpptr,char *line2,filamenttypeptr filty
 			firstline2=0; }
 		else
 			pfpcode=Parse_ReadLine(&pfp,word,&line2,errstring);
-			*pfpptr=pfp;
-			CHECKS(pfpcode!=3,"%s",errstring);
 
-			if(pfpcode==0);																// already taken care of
-			else if(pfpcode==2) {													// end reading
-				done=1; }
-			else if(!strcmp(word,"end_filament")) {				// end_filament_type
-				CHECKS(!line2,"unexpected text following end_filament");
-				return 0; }
-			else if(!line2) {															// just word
-				CHECKS(0,"unknown word or missing parameter"); }
-			else {
-				fil=filreadstring(sim,pfp,fil,filtype,word,line2);
-				CHECK(fil); 															// failed but error has already been sent
-				filtype=fil->filtype; }}
+        *pfpptr=pfp;
+        CHECKS(pfpcode!=3,"%s",errstring);
+
+        if(pfpcode==0);																// already taken care of
+        else if(pfpcode==2) {													// end reading
+            done=1; }
+        else if(!strcmp(word,"end_filament")) {				// end_filament_type
+            CHECKS(!line2,"unexpected text following end_filament");
+            return 0; }
+        else if(!line2) {															// just word
+            CHECKS(0,"unknown word or missing parameter"); }
+        else {
+            fil=filreadstring(sim,pfp,fil,filtype,word,line2);
+            CHECK(fil); 															// failed but error has already been sent
+            filtype=fil->filtype; }}
 
 	CHECKS(0,"end of file encountered before end_filament statement");	// end of file
 

--- a/source/python/Simulation.cpp
+++ b/source/python/Simulation.cpp
@@ -9,9 +9,14 @@
 
 using namespace std;
 
-Simulation::Simulation(vector<double> &low, vector<double> &high,
-                       vector<string> &boundary_type)
-    : low_(low), high_(high), curtime_(0.0), initDisplay_(false), debug_(false)
+Simulation::Simulation(vector<double>& low,
+  vector<double>& high,
+  vector<string>& boundary_type)
+  : low_(low)
+  , high_(high)
+  , curtime_(0.0)
+  , initDisplay_(false)
+  , debug_(false)
 {
     assert(low.size() == high.size());
 
@@ -20,8 +25,7 @@ Simulation::Simulation(vector<double> &low, vector<double> &high,
 
     assert(boundary_type.size() == getDim());
 
-    for (size_t d = 0; d < getDim(); d++)
-    {
+    for (size_t d = 0; d < getDim(); d++) {
         string t = boundary_type[d];
         if (t.size() == 1)
             smolSetBoundaryType(sim_, d, -1, t[0]);
@@ -32,54 +36,71 @@ Simulation::Simulation(vector<double> &low, vector<double> &high,
 }
 
 // Factory function.
-Simulation::Simulation(const char *filepath, const char *flags)
-    : curtime_(0.0), initDisplay_(false), debug_(false)
+Simulation::Simulation(const char* filepath, const char* flags)
+  : curtime_(0.0)
+  , initDisplay_(false)
+  , debug_(false)
 {
     auto path = splitPath(string(filepath));
-    sim_ =
-        smolPrepareSimFromFile(path.first.c_str(), path.second.c_str(), flags);
+    sim_ = smolPrepareSimFromFile(path.first.c_str(), path.second.c_str(), flags);
 }
 
-Simulation::~Simulation() { smolFreeSim(sim_); }
+Simulation::~Simulation()
+{
+    smolFreeSim(sim_);
+}
 
-size_t Simulation::getDim() const
+size_t
+Simulation::getDim() const
 {
     assert(sim_->dim >= 0);
     return (size_t)sim_->dim;
 }
 
-bool Simulation::initialize()
+map<string, size_t>
+Simulation::count() const
+{
+    map<string, size_t> res{
+#ifdef ENABLE_PYTHON_CALLBACK
+        { "functions", sim_->ncallbacks },
+#endif
+        { "dim", sim_->dim },
+        { "variables", sim_->nvar }
+    };
+
+    res["species"] = sim_->mols ? sim_->mols->nspecies : 0;
+    res["compartment"] = sim_->cmptss ? sim_->cmptss->ncmpt : 0;
+    res["surface"] = sim_->srfss ? sim_->srfss->nsrf : 0;
+
+    return res;
+}
+
+bool
+Simulation::initialize()
 {
     if (sim_)
         return true;
 
-    if (getDim() == 0 || getDim() > 3)
-    {
-        cerr << __FUNCTION__ << ": dim must be between 0 and 3. Got "
-             << getDim() << endl;
+    if (getDim() == 0 || getDim() > 3) {
+        cerr << __FUNCTION__ << ": dim must be between 0 and 3. Got " << getDim() << endl;
         return false;
     }
 
-    if (low_.size() != getDim())
-    {
+    if (low_.size() != getDim()) {
         cerr << __FUNCTION__ << ": missing lowbounds" << endl;
         return false;
     }
 
-    if (high_.size() != getDim())
-    {
+    if (high_.size() != getDim()) {
         cerr << __FUNCTION__ << ": missing highbounds" << endl;
         return false;
     }
 
-    for (size_t d = 0; d < getDim(); d++)
-    {
-        if (low_[d] >= high_[d])
-        {
+    for (size_t d = 0; d < getDim(); d++) {
+        if (low_[d] >= high_[d]) {
             cerr << __FUNCTION__ << ": lowbounds must be < highbounds"
-                 << " which is not true at index " << d
-                 << " where lowbounds is " << low_[d] << " and highbound is "
-                 << high_[d] << endl;
+                 << " which is not true at index " << d << " where lowbounds is "
+                 << low_[d] << " and highbound is " << high_[d] << endl;
             return false;
         }
     }
@@ -102,7 +123,8 @@ bool Simulation::initialize()
  *
  * @return true.
  */
-bool Simulation::setModelpath(const string &modelpath)
+bool
+Simulation::setModelpath(const string& modelpath)
 {
     assert(sim_);
     auto p = splitPath(modelpath);
@@ -111,15 +133,13 @@ bool Simulation::setModelpath(const string &modelpath)
     return true;
 }
 
-ErrorCode Simulation::runSim(double stoptime, double dt, bool display,
-                             bool overwrite)
+ErrorCode
+Simulation::runSim(double stoptime, double dt, bool display, bool overwrite)
 {
     ErrorCode er;
 
-    if (!sim_)
-    {
-        if (!initialize())
-        {
+    if (!sim_) {
+        if (!initialize()) {
             cerr << __FUNCTION__ << ": Could not initialize sim." << endl;
             return ECerror;
         }
@@ -128,29 +148,25 @@ ErrorCode Simulation::runSim(double stoptime, double dt, bool display,
     gl2glutInit(0, NULL);
 
     er = smolOpenOutputFiles(sim_, overwrite);
-    if (er != ErrorCode::ECok)
-    {
+    if (er != ErrorCode::ECok) {
         cerr << __FUNCTION__ << ": Could not open output files." << endl;
         return er;
     }
 
     auto er1 = smolSetTimeStep(sim_, dt);
     auto er2 = smolSetTimeStop(sim_, stoptime);
-    if (er1 != ErrorCode::ECok || er2 != ErrorCode::ECok)
-    {
+    if (er1 != ErrorCode::ECok || er2 != ErrorCode::ECok) {
         cerr << __FUNCTION__ << ": Could not update simtimes." << endl;
         return er;
     }
 
     er = smolUpdateSim(sim_);
-    if (er != ErrorCode::ECok)
-    {
+    if (er != ErrorCode::ECok) {
         cerr << __FUNCTION__ << ": Could not update simstruct." << endl;
         return er;
     }
 
-    if (display && !initDisplay_)
-    {
+    if (display && !initDisplay_) {
         smolDisplaySim(sim_);
         initDisplay_ = true;
     }
@@ -161,23 +177,23 @@ ErrorCode Simulation::runSim(double stoptime, double dt, bool display,
     return er;
 }
 
-ErrorCode Simulation::runUntil(const double breaktime, const double dt,
-                               bool display, bool overwrite)
+ErrorCode
+Simulation::runUntil(const double breaktime,
+  const double dt,
+  bool display,
+  bool overwrite)
 {
     assert(sim_);
 
-    if (!sim_)
-    {
-        if (!initialize())
-        {
+    if (!sim_) {
+        if (!initialize()) {
             cerr << __FUNCTION__ << ": Could not initialize sim." << endl;
             return ECerror;
         }
     }
 
     auto er = smolOpenOutputFiles(sim_, overwrite);
-    if (er != ErrorCode::ECok)
-    {
+    if (er != ErrorCode::ECok) {
         cerr << __FUNCTION__ << ": Simulation skipped." << endl;
     }
 
@@ -186,23 +202,25 @@ ErrorCode Simulation::runUntil(const double breaktime, const double dt,
         smolSetTimeStep(sim_, dt);
     smolUpdateSim(sim_);
 
-    if (display && (!initDisplay_))
-    {
+    if (display && (!initDisplay_)) {
         smolDisplaySim(sim_);
         initDisplay_ = true;
     }
     return smolRunSimUntil(sim_, breaktime);
 }
 
-bool Simulation::connect(const py::function &func, const py::object &target,
-                         const size_t step, const py::list &args)
+bool
+Simulation::connect(const py::function& func,
+  const py::object& target,
+  const size_t step,
+  const py::list& args)
 {
     assert(sim_->ncallbacks < MAX_PY_CALLBACK);
-    if (sim_->ncallbacks >= MAX_PY_CALLBACK)
-    {
-        py::print("Error: Maximum of ", MAX_PY_CALLBACK,
-                  " callbacks are allowed. Current number of callbacks: ",
-                  sim_->ncallbacks);
+    if (sim_->ncallbacks >= MAX_PY_CALLBACK) {
+        py::print("Error: Maximum of ",
+          MAX_PY_CALLBACK,
+          " callbacks are allowed. Current number of callbacks: ",
+          sim_->ncallbacks);
         return false;
     }
 
@@ -220,35 +238,54 @@ bool Simulation::connect(const py::function &func, const py::object &target,
 }
 
 // get the pointer
-simptr Simulation::getSimPtr() const
+simptr
+Simulation::getSimPtr() const
 {
     assert(sim_);
     return sim_;
 }
 
 // set the pointer.
-void Simulation::setSimPtr(simptr sim) { sim_ = sim; }
+void
+Simulation::setSimPtr(simptr sim)
+{
+    sim_ = sim;
+}
 
-void Simulation::setCurtime(double curtime) { curtime_ = curtime; }
+void
+Simulation::setCurtime(double curtime)
+{
+    curtime_ = curtime;
+}
 
-double Simulation::getCurtime() const { return curtime_; }
+double
+Simulation::getCurtime() const
+{
+    return curtime_;
+}
 
-bool Simulation::isValid() { return sim_ ? true : false; }
+bool
+Simulation::isValid()
+{
+    return sim_ ? true : false;
+}
 
-pair<vector<double>, vector<double>> Simulation::getBoundaries(void)
+pair<vector<double>, vector<double>>
+Simulation::getBoundaries(void)
 {
     vector<double> low;
     vector<double> high;
-    for (size_t d = 0; d < (size_t) sim_->dim; d++)
-    {
+    for (size_t d = 0; d < (size_t)sim_->dim; d++) {
         low.push_back(sim_->wlist[2 * d]->pos);
         high.push_back(sim_->wlist[2 * d + 1]->pos);
     }
     return make_pair(low, high);
 }
 
-void Simulation::addCommand(const string &cmd, char cmd_type,
-                            const map<string, double> &kwargs)
+void
+Simulation::addCommand(const string& cmd,
+  char cmd_type,
+  const map<string, double>& kwargs)
 {
     auto c = make_unique<Command>(getSimPtr(), cmd.c_str(), cmd_type, kwargs);
     c->addCommandToSimptr();
@@ -259,7 +296,8 @@ void Simulation::addCommand(const string &cmd, char cmd_type,
     // printf("*** Simulation.cpp Simulation::addCommand B\n"); //??
 }
 
-void Simulation::addCommandStr(char *cmd)
+void
+Simulation::addCommandStr(char* cmd)
 {
     auto c = make_unique<Command>(getSimPtr(), cmd);
     c->addCommandToSimptr();

--- a/source/python/Simulation.h
+++ b/source/python/Simulation.h
@@ -33,11 +33,10 @@ class Simulation
 {
 
   public:
-    Simulation(vector<double> &low, vector<double> &high,
-               vector<string> &boundary_type);
+    Simulation(vector<double>& low, vector<double>& high, vector<string>& boundary_type);
 
     // Factory function.
-    Simulation(const char *filepath, const char *flags);
+    Simulation(const char* filepath, const char* flags);
 
     ~Simulation();
 
@@ -56,15 +55,19 @@ class Simulation
      *
      * @return true.
      */
-    bool setModelpath(const string &modelpath);
+    bool setModelpath(const string& modelpath);
 
     ErrorCode runSim(double stoptime, double dt, bool display, bool overwrite);
 
-    ErrorCode runUntil(const double breaktime, const double dt, bool display,
-                       bool overwrite);
+    ErrorCode runUntil(const double breaktime,
+      const double dt,
+      bool display,
+      bool overwrite);
 
-    bool connect(const py::function &func, const py::object &target,
-                 const size_t step, const py::list &args);
+    bool connect(const py::function& func,
+      const py::object& target,
+      const size_t step,
+      const py::list& args);
 
     // get the pointer
     simptr getSimPtr() const;
@@ -78,12 +81,13 @@ class Simulation
 
     bool isValid();
 
+    map<string, size_t> count() const;
+
     pair<vector<double>, vector<double>> getBoundaries(void);
 
     // Commands
-    void addCommand(const string &cmd, char cmd_type,
-                    const map<string, double> &kwargs);
-    void addCommandStr(char *cmd);
+    void addCommand(const string& cmd, char cmd_type, const map<string, double>& kwargs);
+    void addCommandStr(char* cmd);
 
   private:
     simptr sim_;

--- a/source/python/module.cpp
+++ b/source/python/module.cpp
@@ -418,6 +418,7 @@ PYBIND11_MODULE(_smoldyn, m)
 
       .def("setModelpath", &Simulation::setModelpath)
       .def("getBoundaries", &Simulation::getBoundaries)
+      .def("count", &Simulation::count)
 
       // Simulation extra.
       .def("runSim", &Simulation::runSim)

--- a/source/python/module.cpp
+++ b/source/python/module.cpp
@@ -661,10 +661,10 @@ PYBIND11_MODULE(_smoldyn, m)
             return sim.addCommand(cmd, cmd_type, options);
         })
 
-			.def("runCommand",
-				[](Simulation& sim, const char* commandstring) {
-						return smolRunCommand(sim.getSimPtr(), commandstring);
-				})
+      .def("runCommand",
+        [](Simulation& sim, const char* commandstring) {
+            return smolRunCommand(sim.getSimPtr(), commandstring);
+        })
 
       /***************
        *  Molecules  *
@@ -1412,8 +1412,19 @@ PYBIND11_MODULE(_smoldyn, m)
      *  Errors  *
      ************/
     m.def("setDebugMode", &smolSetDebugMode);
-    m.def("errorCodeToString",
-      [](ErrorCode err) { return smolErrorCodeToString(err, tempstring); });
+    m.def("errorCodeToString", [](ErrorCode err) -> string {
+        return string(smolErrorCodeToString(err, tempstring));
+    });
+
+    // Error
+    m.def(
+      "getError",
+      [](bool clear) -> std::tuple<ErrorCode, string> {
+          char errstr[512];
+          auto code = smolGetError(nullptr, errstr, clear);
+          return std::make_tuple(code, string(errstr));
+      },
+      "clear"_a = false);
 
     /*****************************
      *  Read configuration file  *

--- a/source/python/smoldyn/smoldyn.py
+++ b/source/python/smoldyn/smoldyn.py
@@ -176,8 +176,8 @@ class Species(object):
 
         Parameters
         ----------
-        difconst : DiffConst
-            Default value is 0. If a single value is given, all states of the
+        difconst : DiffConst (default '0')
+            If a single value is given, all states of the
             molecule are assigned the same value. To assign state specific
             values, use a dictionary. Missing states will be assigned 0.0.
         """

--- a/source/python/smoldyn/smoldyn.py
+++ b/source/python/smoldyn/smoldyn.py
@@ -7,6 +7,7 @@ __email__ = "dilawar.s.rajput@gmail.com"
 __all__ = [
     "__version__",
     "version",
+    "getError",
     "Simulation",
     "Species",
     "Panel",
@@ -20,8 +21,6 @@ __all__ = [
     "Surface",
     "Port",
     "Partition",
-    #  "MoleculePerBox",
-    #  "Box",
     "Compartment",
     "Reaction",
     "BidirectionalReaction",
@@ -64,6 +63,10 @@ def version():
 
 # alias of version()
 __version__: str = version()
+
+
+def getError(clear: bool = False) -> Tuple[_smoldyn.ErrorCode, str]:
+    return _smoldyn.getError(clear)
 
 
 def _toMS(st: Union[str, _smoldyn.MolecState]) -> _smoldyn.MolecState:

--- a/tests/test_getters.py
+++ b/tests/test_getters.py
@@ -1,0 +1,43 @@
+# Bistable reaction system
+__author__ = "Dilawar Singh"
+__email__ = "dilawar.s.rajput@gmail.com"
+
+import smoldyn
+
+
+def test_getter():
+    s = smoldyn.Simulation(
+        low=[0, 0], high=[10, 10], types="p", output_files=["bistableout.txt"]
+    )
+
+    # species X A B A2 B2
+    X = s.addSpecies("X", difc=0, color="green", display_size=3)
+    A = s.addSpecies("A", difc=1, color="red", display_size=3)
+    B = s.addSpecies("B", difc=1, color="blue", display_size=3)
+    A2 = s.addSpecies("A2", difc=1, color="red", display_size=5)
+    B2 = s.addSpecies("B2", difc=1, color="blue", display_size=5)
+
+    # mol 1 X 5 5
+    X.addToSolution(1, pos=[5, 5])
+
+    express = s.addReaction("express", subs=[X], prds=[X, A, B], rate=1)
+    Adimer = s.addBidirectionalReaction("Adimer", subs=[A, A], prds=[A2], kf=1, kb=1)
+    Bdimer = s.addBidirectionalReaction("Bdimer", subs=[B, B], prds=[B2], kf=1, kb=1)
+    AxB = s.addReaction("AxB", subs=[A2, B], prds=[A2], rate=1)
+    BxA = s.addReaction("BxA", subs=[B2, A], prds=[B2], rate=1)
+    Adegrade = s.addReaction("Adegrade", subs=[A], prds=[], rate=0.01)
+    Bdegrade = s.addReaction("Bdegrade", subs=[B], prds=[], rate=0.01)
+
+    s.addCommand("molcountheader bistableout.txt", cmd_type="B")
+    s.addCommand("molcount bistableout.txt", cmd_type="N", step=10)
+    s.setGraphics("opengl")
+    d = s.count()
+    print(d)
+
+
+def main():
+    test_getter()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -2,41 +2,31 @@
 File: test_sanity.py
 Author: Dilawar Singh
 Email: dilawars@ncbs.res.in
-Description: 
+Description:
     User can create multiple simptr and assign one of them as current simptr.
 """
 # todo: Test a full simulation with configuration changes.
 
 import smoldyn
 
-
-def test_cursim():
-    print("test_cursim")
-    smoldyn.clearAllSimStructs()
-    curSim = smoldyn.getCurSimStruct()
-    print("cursim", curSim)
-    # assert curSim == None, curSim # Not initialized yet.
-    s1 = smoldyn.newSim([0, 0, 0], [10, 10, 10])
-    # assert s1 != curSim, (s1, curSim)
-
-    s2 = smoldyn.newSim([0, 0], [10, 10])
-    assert s2 != s1, (s1, s2)
-    smoldyn.setCurSimStruct(s1)
-    assert s1 == smoldyn.getCurSimStruct()
-
+print(f'Using smoldyn from {smoldyn.__file__}')
 
 def test_newcursim():
     print("test_newcursim")
-    smoldyn.setBoundaries([(0, 1), (0, 1)])
-    cs = smoldyn.getCurSimStruct()
+    s = smoldyn.Simulation(low=(0,0), high=(1,1))
+    cs = s.simptr
     assert cs != None
     print(cs)
 
+def test_get_err():
+    print('Testing test_get_err')
+    s = smoldyn.Simulation(low=(0,0), high=(1,1))
+    a = smoldyn.getError()
+    print(a)
 
 def main():
-    """TODO: Docstring for main.
-    :returns: TODO
-
-    """
     test_newcursim()
-    test_cursim()
+    test_get_err()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- `smolGetError` is `getError` (smoldyn.py).
- Added method `count` to the class `Simulation` that returns a dict of counts of major elements. e.g. `{'compartment': 0, 'dim': 2, 'functions': 0, 'species': 6, 'surface': 0, 'variables': 5}`. It can be extended to include more components. Also see `test_getters.py` file.