### PR TITLE
Update xvfb-startup.sh

### DIFF
--- a/scripts/xvfb-startup.sh
+++ b/scripts/xvfb-startup.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
+set -e
 Xvfb $DISPLAY -ac -screen 0 "$XVFB_RES" -nolisten tcp $XVFB_ARGS &
 XVFB_PROC=$!
 sleep 1
 "$@"
-kill $XVFB_PROC
-exit 0
+result=$?
+kill $XVFB_PROC || true
+exit $result

--- a/scripts/xvfb-startup.sh
+++ b/scripts/xvfb-startup.sh
@@ -4,3 +4,4 @@ XVFB_PROC=$!
 sleep 1
 "$@"
 kill $XVFB_PROC
+exit 0

--- a/scripts/xvfb-startup.sh
+++ b/scripts/xvfb-startup.sh
@@ -3,6 +3,7 @@ set -e
 Xvfb $DISPLAY -ac -screen 0 "$XVFB_RES" -nolisten tcp $XVFB_ARGS &
 XVFB_PROC=$!
 sleep 1
+set +e
 "$@"
 result=$?
 kill $XVFB_PROC || true


### PR DESCRIPTION
Set an exit 0 at the end to prevent docker image run failure even when simulation was successful. The script exits with an error if the process does not exist.

@jonrkarr This should fix the issue with running Smoldyn on the hpc