### PR TITLE
fix: bump biosimulators-simularium version in python setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ log
 htmlcov/
 .idea/
 build-install.sh
+run.sh

--- a/source/python/setup.py.in
+++ b/source/python/setup.py.in
@@ -63,7 +63,7 @@ setuptools.setup(
             "biosimulators-utils[logging]>=0.1.124",
             "numpy",
             "pandas",
-            "biosimulators-simularium>=0.5.24"
+            "biosimulators-simularium>=0.5.27"
         ],
         "biosimulators-dev": [
             "flake8",

--- a/source/python/smoldyn/biosimulators/tests.py
+++ b/source/python/smoldyn/biosimulators/tests.py
@@ -1,0 +1,25 @@
+import os
+import json
+from tempfile import mkdtemp as temp_dir
+from smoldyn.biosimulators.combine import exec_sedml_docs_in_combine_archive as exec_archive
+
+
+def test_simularium():
+    archive_path = '/Users/alex/Desktop/uchc_work/repos/Smoldyn/examples/S99_more/Min/Min1.omex'
+    output_dir = '/Users/alex/Desktop/uchc_work'
+
+    exec_archive(archive_path, output_dir)
+    files = [f for f in os.listdir(output_dir)]
+    print(f'THE FILES:\n{files}\n')
+    for f in files:
+        if 'simularium' in f:
+            with open(os.path.join(output_dir, f), 'r') as fp:
+                data = json.load(fp)
+                print(f'THE SIMULARIUM:\n{data}')
+
+
+
+
+
+if __name__ == '__main__':
+    test_simularium()


### PR DESCRIPTION
_What does this PR do?:_
- Updates the `biosimulators-simularium` optional dependency in `setup.py.in`
- Adds a test file in the `biosimulators` Python library.