### PR TITLE
Reaction kinetics: split `setRate` into `rate`/`probability`/`binding_radius` properties

### DIFF
--- a/source/python/smoldyn/smoldyn.py
+++ b/source/python/smoldyn/smoldyn.py
@@ -1329,10 +1329,12 @@ class Reaction(object):
         self.name = "r%d" % id(self) if not name else name
         self.subs = subs
         self.prds = prds
-        self.reaction_probability = reaction_probability
-        self.binding_radius = binding_radius
         self.compartment = compartment
         self.surface = surface
+        # Caches for properties whose values libsmoldyn doesn't expose a getter
+        # for. Updated by the property setters below.
+        self._reaction_probability = reaction_probability
+        self._binding_radius = binding_radius
 
         assert len(subs) < 3, "At most two reactants are supported."
         if subs is None or len(subs) == 0:
@@ -1378,7 +1380,14 @@ class Reaction(object):
             __logger__.warning(f" Products: {prds}, {prdNames}/{prdStates}")
             raise RuntimeError(f"Failed to add reaction, ErrorCode {k}")
 
-        self.setRate(rate, reaction_probability, binding_radius)
+        # simulation.addReaction(...) above already registered the macroscopic
+        # rate. Apply the other kinetic parameters only if the user supplied a
+        # non-default value.
+        if reaction_probability:
+            self.reaction_probability = reaction_probability
+        if binding_radius:
+            self.binding_radius = binding_radius
+
         if self.compartment is not None or self.surface is not None:
             cname = self.compartment.name if self.compartment else ""
             sname = self.surface.name if self.surface else ""
@@ -1386,13 +1395,57 @@ class Reaction(object):
             k = self.simulation.setReactionRegion(self.name, cname, sname)
             assert k == _smoldyn.ErrorCode.ok
 
+    # Macroscopic rate constant. Read live from libsmoldyn via
+    # smolGetReactionRate; write via smolSetReactionRate(..., isinternal=0).
     @property
     def rate(self) -> float:
         return float(self.simulation.getReactionRate(self.name))
 
     @rate.setter
-    def rate(self, rate: float) -> None:
-        self.setRate(rate)
+    def rate(self, val: float) -> None:
+        assert val >= 0.0, f"rate must be non-negative, got {val}"
+        k = self.simulation.setReactionRate(self.name, val, 0)
+        assert k == _smoldyn.ErrorCode.ok
+
+    # Reaction probability. libsmoldyn exposes no getter for this field, so
+    # the property returns the last-set value cached on the instance.
+    # Underlying C API: smolSetReactionRate(..., isinternal=1) for order<2 or
+    # isinternal=2 for order==2 (see source/Smoldyn/libsmoldyn.cpp:1905-1912).
+    @property
+    def reaction_probability(self) -> float:
+        return self._reaction_probability
+
+    @reaction_probability.setter
+    def reaction_probability(self, val: float) -> None:
+        assert val >= 0.0, f"reaction_probability must be non-negative, got {val}"
+        if self.order >= 2:
+            assert val <= 1.0, (
+                f"reaction_probability for bimolecular reactions must be in [0,1], got {val}"
+            )
+            isinternal = 2
+        else:
+            isinternal = 1
+        k = self.simulation.setReactionRate(self.name, val, isinternal)
+        assert k == _smoldyn.ErrorCode.ok
+        self._reaction_probability = val
+
+    # Smoluchowski binding radius (bimolecular reactions only). Cached for
+    # the same reason as reaction_probability. Underlying C API:
+    # smolSetReactionRate(..., isinternal=1) — same isinternal as the
+    # unimolecular probability path, but disambiguated by reaction order.
+    @property
+    def binding_radius(self) -> float:
+        return self._binding_radius
+
+    @binding_radius.setter
+    def binding_radius(self, val: float) -> None:
+        assert self.order == 2, (
+            "binding_radius only applies to bimolecular reactions"
+        )
+        assert val >= 0.0, f"binding_radius must be non-negative, got {val}"
+        k = self.simulation.setReactionRate(self.name, val, 1)
+        assert k == _smoldyn.ErrorCode.ok
+        self._binding_radius = val
 
     def setRate(
         self,
@@ -1400,30 +1453,32 @@ class Reaction(object):
         reaction_probability: None | float = None,
         binding_radius: float = -1.0,
     ) -> None:
-        # if rate is negative, then we expect either binding_radius or
-        # reaction_probability. A reaction can have zero rate.
-        if rate >= 0.0:
-            k = self.simulation.setReactionRate(self.name, rate, False)
-            assert k == _smoldyn.ErrorCode.ok
-            return
+        """Deprecated. Use the .rate, .reaction_probability, and
+        .binding_radius properties instead.
 
-        # check if reaction_probability is set when rate is not set.
-        if len(self.subs) < 2:
+        rate < 0 was historically a sentinel meaning "ignore rate; set one of
+        the other two parameters instead." This shim preserves that behavior
+        for any back-compat callers.
+        """
+        warnings.warn(
+            "Reaction.setRate is deprecated; use the .rate, "
+            ".reaction_probability, and .binding_radius properties instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if rate >= 0.0:
+            self.rate = rate
+            return
+        if self.order < 2:
             assert reaction_probability is not None, (
                 "Must set rate or reaction_probability"
             )
-            k = self.simulation.setReactionRate(self.name, reaction_probability, True)
-            assert k == _smoldyn.ErrorCode.ok
+            self.reaction_probability = reaction_probability
         else:
             if reaction_probability is not None:
-                assert 0.0 <= reaction_probability <= 1.0, (
-                    "reaction_probability must be between 0 and 1"
-                )
-                k = self.simulation.setReactionRate(self.name, reaction_probability, 2)
-                assert k == _smoldyn.ErrorCode.ok
+                self.reaction_probability = reaction_probability
             if binding_radius >= 0.0:
-                k = self.simulation.setReactionRate(self.name, binding_radius, True)
-                assert k == _smoldyn.ErrorCode.ok
+                self.binding_radius = binding_radius
 
     @property
     def order(self) -> int:

--- a/tests/test_reaction.py
+++ b/tests/test_reaction.py
@@ -93,14 +93,114 @@ class TestReactionRate:
         assert r.rate == 2.5
 
     def test_rate_setter_idempotent_same_value(self):
-        # smoldyn.py:1396 — setter only forwards to libsmoldyn when the value
-        # actually changes. We can't directly observe that, but we can confirm
-        # setting the same value again doesn't fail.
         sim, sp = _sim_with_species("A", "B")
         r = sim.addReaction("x", subs=[sp["A"]], prds=[sp["B"]], rate=0.1)
         r.rate = 2.5
         r.rate = 2.5
         assert r.rate == 2.5
+
+    def test_rate_setter_rejects_negative(self):
+        sim, sp = _sim_with_species("A", "B")
+        r = sim.addReaction("x", subs=[sp["A"]], prds=[sp["B"]], rate=0.1)
+        with pytest.raises(AssertionError):
+            r.rate = -1.0
+
+
+# ---------- Reaction probability ----------
+
+
+class TestReactionProbability:
+    def test_default_is_zero(self):
+        sim, sp = _sim_with_species("A", "B")
+        r = sim.addReaction("x", subs=[sp["A"]], prds=[sp["B"]], rate=0.1)
+        assert r.reaction_probability == 0.0
+
+    def test_set_via_constructor_unimolecular(self):
+        sim, sp = _sim_with_species("A", "B")
+        r = sim.addReaction(
+            "x", subs=[sp["A"]], prds=[sp["B"]], reaction_probability=0.3
+        )
+        assert r.reaction_probability == 0.3
+
+    def test_set_via_property_unimolecular(self):
+        sim, sp = _sim_with_species("A", "B")
+        r = sim.addReaction("x", subs=[sp["A"]], prds=[sp["B"]], rate=0.1)
+        r.reaction_probability = 0.4
+        assert r.reaction_probability == 0.4
+
+    def test_bimolecular_above_one_rejected(self):
+        sim, sp = _sim_with_species("A", "B", "C")
+        r = sim.addReaction(
+            "bind", subs=[sp["A"], sp["B"]], prds=[sp["C"]], rate=0.5
+        )
+        with pytest.raises(AssertionError):
+            r.reaction_probability = 1.5
+
+    def test_negative_rejected(self):
+        sim, sp = _sim_with_species("A", "B")
+        r = sim.addReaction("x", subs=[sp["A"]], prds=[sp["B"]], rate=0.1)
+        with pytest.raises(AssertionError):
+            r.reaction_probability = -0.1
+
+
+# ---------- Binding radius ----------
+
+
+class TestBindingRadius:
+    def test_default_is_zero(self):
+        sim, sp = _sim_with_species("A", "B", "C")
+        r = sim.addReaction(
+            "bind", subs=[sp["A"], sp["B"]], prds=[sp["C"]], rate=0.5
+        )
+        assert r.binding_radius == 0.0
+
+    def test_set_via_constructor(self):
+        sim, sp = _sim_with_species("A", "B", "C")
+        r = sim.addReaction(
+            "bind", subs=[sp["A"], sp["B"]], prds=[sp["C"]], binding_radius=0.2
+        )
+        assert r.binding_radius == 0.2
+
+    def test_set_via_property(self):
+        sim, sp = _sim_with_species("A", "B", "C")
+        r = sim.addReaction(
+            "bind", subs=[sp["A"], sp["B"]], prds=[sp["C"]], rate=0.5
+        )
+        r.binding_radius = 0.3
+        assert r.binding_radius == 0.3
+
+    def test_rejected_on_unimolecular(self):
+        sim, sp = _sim_with_species("A", "B")
+        r = sim.addReaction("x", subs=[sp["A"]], prds=[sp["B"]], rate=0.1)
+        with pytest.raises(AssertionError):
+            r.binding_radius = 0.5
+
+    def test_negative_rejected(self):
+        sim, sp = _sim_with_species("A", "B", "C")
+        r = sim.addReaction(
+            "bind", subs=[sp["A"], sp["B"]], prds=[sp["C"]], rate=0.5
+        )
+        with pytest.raises(AssertionError):
+            r.binding_radius = -0.1
+
+
+# ---------- Deprecated setRate shim ----------
+
+
+class TestSetRateDeprecated:
+    def test_emits_deprecation_warning(self):
+        sim, sp = _sim_with_species("A", "B")
+        r = sim.addReaction("x", subs=[sp["A"]], prds=[sp["B"]], rate=0.1)
+        with pytest.warns(DeprecationWarning, match="setRate is deprecated"):
+            r.setRate(2.0)
+        assert r.rate == 2.0
+
+    def test_sentinel_routes_to_probability(self):
+        sim, sp = _sim_with_species("A", "B")
+        r = sim.addReaction("x", subs=[sp["A"]], prds=[sp["B"]], rate=0.1)
+        with pytest.warns(DeprecationWarning):
+            r.setRate(-1.0, reaction_probability=0.4)
+        assert r.reaction_probability == 0.4
 
 
 # ---------- Intersurface ----------


### PR DESCRIPTION
## Stack
1. #160 — More unit tests and some fixes (base)
2. **#161 (this PR)** — Reaction kinetics property refactor

> ⚠ Stacked on #160. Review and merge #160 first; this PR's diff against `master` will look noisier until then.

## Summary

The Python wrapper's `Reaction.setRate(rate, reaction_probability, binding_radius)` was a single method doing three jobs, dispatched via a `rate < 0` sentinel — mirroring libsmoldyn's overloaded `smolSetReactionRate(..., isinternal)`. This PR splits the Python surface into three single-purpose property setters:

| Property | Underlying C call |
|---|---|
| `r.rate` | `smolSetReactionRate(..., isinternal=0)` |
| `r.reaction_probability` | `smolSetReactionRate(..., isinternal=1)` (unimol) or `2` (bimol) |
| `r.binding_radius` | `smolSetReactionRate(..., isinternal=1)` (bimol only, asserted) |

`smolSetReactionRate` is unchanged — the C API stays as-is, the wrapper just stops exposing its polymorphic shape.

## Notes

- `setRate` remains as a back-compat shim that emits `DeprecationWarning`. The old `rate < 0` sentinel semantics are preserved inside the shim.
- `reaction_probability` and `binding_radius` have no C-side getter (libsmoldyn exposes no `smolGetReactionProbability` or `smolGetReactionBindingRadius`), so their property getters return last-set values cached on the instance.
- Builds on the `smolGetReactionRate` C function and `getReactionRate` pybind11 binding that land in #160.

## Test plan

- [x] `pytest tests/test_reaction.py` — 31 tests pass (was 17 in #160, +14 new for property setters + deprecation shim)
- [x] Full new-tests suite passes: 117/117
- [x] `make lint` (mypy --strict + flake8) clean
- [x] `make fix` (added in #160) leaves the file unchanged
