### PR TITLE
ci: use slim-trixie for biosimulator docker image

### DIFF
--- a/scripts/Dockerfile-BioSimulators
+++ b/scripts/Dockerfile-BioSimulators
@@ -14,7 +14,7 @@ LABEL \
     org.opencontainers.image.vendor="Steven Andrews" \
     org.opencontainers.image.licenses="LGPL-3.0-only" \
     \
-    base_image="python:3.10-slim-bullseye" \
+    base_image="python:3.10-slim-trixie" \
     version="${VERSION}" \
     software="Smoldyn" \
     software.version="${VERSION}" \
@@ -31,7 +31,7 @@ RUN apt-get -y update \
     && apt-get install --no-install-recommends -y \
         xvfb \
         libxrender1 \
-        libgl1-mesa-glx \
+        libgl1 libglx-mesa0 \
         libfreetype6 \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir /tmp/.X11-unix \

--- a/scripts/Dockerfile-BioSimulators
+++ b/scripts/Dockerfile-BioSimulators
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye
+FROM python:3.10-slim-trixie
 
 ARG VERSION=""
 


### PR DESCRIPTION
`bullseye` is EOL, updating to `trixie`. 